### PR TITLE
0010: on_timeout and on_failure as root elements of a workflow

### DIFF
--- a/0010/README.md
+++ b/0010/README.md
@@ -1,7 +1,7 @@
 ---
 id: 0010
 title: Workflow behavior for on_timeout and on_failure
-status: discussion 
+status: abandoned 
 authors: Gaurav Gahlot <gauravgahlot0107@gmail.com>
 ---
 

--- a/0010/README.md
+++ b/0010/README.md
@@ -1,0 +1,56 @@
+---
+id: 0010
+title: Workflow behavior for on_timeout and on_failure
+status: discussion 
+authors: Gaurav Gahlot <gauravgahlot0107@gmail.com>
+---
+
+## Summary:
+
+When a workflow action runs out of time or fails, consequently its parent task and workflow are marked as timeout or failed.
+In such scenarios, either `on_timeout` or `on_failure` actions must be executed.
+Currently, both `on_timeout` or `on_failure` are not actions but a command that is executed after an action timeout or fails.
+
+## Goals:
+
+The primary goals are:
+* `on_timeout` and `on_failure` to be:
+  * removed from action level
+  * added as root level elements in a workflow template
+  * converted to actions, instead of accepting commands
+* `on_timeout` action should be executed when an action (irrespective of its task) runs out of time
+* `on_failure` action should be executed when an action (irrespective of its task) fails
+
+## Content: 
+
+- When a workflow action runs out of time or fails, consequently its parent task and workflow are marked as timeout or failed.
+- In such scenarios, either `on_timeout` or `on_failure` actions must be executed.
+- Currently, both `on_timeout` or `on_failure` are not actions but a command that is executed after an action timeout or fails.
+- Both the entities are supported at the action level.
+- As we convert them to a workflow action, they will be removed from action level and added as root level elements in a workflow.
+- They will support all the elements that make an action and will take the following form:
+
+```
+...
+on_failure:
+  image: on-failure
+  timeout: 90
+    volumes:
+      - ./host-path:/container-path
+    environment:
+      key: value
+on_timeout:
+  image: on-timeout
+  timeout: 90
+    volumes:
+      - ./host-path:/container-path
+    environment:
+      key: value
+...
+```
+- The complete sample template for a workflow with `on_timeout` and `on_failure` can be found [here](sample.tmpl)
+
+
+## Progress:
+
+Post discussion, this proposal will be taken forward with implementation under the [Tink repository](https://github.com/tinkerbell/tink/).

--- a/0010/sample.tmpl
+++ b/0010/sample.tmpl
@@ -1,0 +1,34 @@
+version: '0.1'
+name: osie_provisioning
+global_timeout: 600
+tasks:
+- name: "disk wipe"
+  worker: "{{.device_1}}"
+  actions:
+  - name: "disk_wipe"
+    image: disk-wipe
+    timeout: 60
+    volumes:
+      - ./host-path:/container-path
+    environment:
+      key: value
+- name: "disk partition"
+  worker: "{{.device_1}}"
+  actions:
+  - name: "disk_partition"
+    image: disk-partition
+    timeout: 50
+on_failure:
+  image: on-failure
+  timeout: 90
+    volumes:
+      - ./host-path:/container-path
+    environment:
+      key: value
+on_timeout:
+  image: on-timeout
+  timeout: 90
+    volumes:
+      - ./host-path:/container-path
+    environment:
+      key: value


### PR DESCRIPTION
## Description
Add `on_timeout` and `on_failure` actions as root elements of a workflow.

## Why is this needed
To add better support for what a user can do when a workflow fails or timeout. 