### PR TITLE
update mailing list link in GOVERNANCE.md

### DIFF
--- a/proposals/0024/GOVERNANCE.md
+++ b/proposals/0024/GOVERNANCE.md
@@ -42,7 +42,7 @@ Members are expected to remain active contributors to the community.
   - Authoring or reviewing PRs on GitHub
   - Filing or commenting on issues on GitHub
   - Contributing to community discussions (e.g. meetings, Slack, email discussion forums)
-- Subscribed to [tinkerbell-contributors@googlegroups.com]
+- Subscribed to <https://lists.cncf.io/g/cncf-tinkerbell-dev>
 - Actively contributing to 1 or more repository.
 - Sponsored by 2 Reviewers. **Note the following requirements for sponsors**:
   - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.


### PR DESCRIPTION
## Description

Updates the link to the mailing list in the maintainership PR template.



## Why is this needed

The Google Group mailing list has been replaced with the CNCF group.

https://groups.google.com/g/tinkerbell-contributors/c/dLcr0_-1Pas

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade


-----
[View rendered proposals/0024/GOVERNANCE.md](https://github.com/tinkerbell/proposals/blob/displague-patch-1/proposals/0024/GOVERNANCE.md)